### PR TITLE
Correct version of Ansible and ACM certificate

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -1,0 +1,32 @@
+#--------------------------------------------------------------------------------
+# Set up ACM certificate for our ALB / ELB
+#--------------------------------------------------------------------------------
+resource aws_acm_certificate public_cert {
+  domain_name = "${substr(local.dns_master, 0, length(local.dns_master) - 1)}"
+
+  subject_alternative_names = [
+    "${local.acm_san}",
+  ]
+
+  validation_method = "DNS"
+
+  tags {
+    Name        = "Openshift certificate ${var.environment}"
+    Environment = "${var.environment}"
+    Terraform   = "true"
+  }
+}
+
+# Validate the cert
+resource aws_route53_record public_cert_validation {
+  count   = "${1 + length(local.acm_san)}"                                                                              # the 1 + is for the main domain
+  name    = "${lookup(aws_acm_certificate.public_cert.domain_validation_options[count.index], "resource_record_name")}"
+  type    = "${lookup(aws_acm_certificate.public_cert.domain_validation_options[count.index], "resource_record_type")}"
+  zone_id = "${data.aws_route53_zone.selected.zone_id}"
+
+  records = [
+    "${lookup(aws_acm_certificate.public_cert.domain_validation_options[count.index], "resource_record_value")}",
+  ]
+
+  ttl = 60
+}

--- a/dns.tf
+++ b/dns.tf
@@ -4,7 +4,7 @@ data "aws_route53_zone" "selected" {
 
 resource "aws_route53_record" "publicrouter" {
   zone_id = "${data.aws_route53_zone.selected.zone_id}"
-  name    = "*.public.${var.environment}.${data.aws_route53_zone.selected.name}"
+  name    = "${local.dns_public_router}"
   type    = "A"
 
   alias {
@@ -16,7 +16,7 @@ resource "aws_route53_record" "publicrouter" {
 
 resource "aws_route53_record" "master" {
   zone_id = "${data.aws_route53_zone.selected.zone_id}"
-  name    = "${var.environment}.${data.aws_route53_zone.selected.name}"
+  name    = "${local.dns_master}"
   type    = "A"
 
   alias {
@@ -28,7 +28,7 @@ resource "aws_route53_record" "master" {
 
 resource "aws_route53_record" "internal_master" {
   zone_id = "${data.aws_route53_zone.selected.zone_id}"
-  name    = "${var.environment}_internal.${data.aws_route53_zone.selected.name}"
+  name    = "${local.dns_master_internal}"
   type    = "A"
 
   alias {

--- a/infra_lb.tf
+++ b/infra_lb.tf
@@ -11,10 +11,11 @@ resource "aws_elb" "infra" {
   }
 
   listener {
-    instance_port     = 443
-    instance_protocol = "tcp"
-    lb_port           = 443
-    lb_protocol       = "tcp"
+    instance_port      = 443
+    instance_protocol  = "https"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${aws_acm_certificate.public_cert.arn}"
   }
 
   health_check {

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  # Some DNS that we will set up
+  dns_public_router   = "*.public.${var.environment}.${data.aws_route53_zone.selected.name}"
+  dns_master          = "${var.environment}.${data.aws_route53_zone.selected.name}"
+  dns_master_internal = "${var.environment}_internal.${data.aws_route53_zone.selected.name}"
+
+  # List of SAN that we wish to set on the ACM cert
+  acm_san = [
+    "${substr(local.dns_public_router, 0, length(local.dns_public_router) - 1)}",
+  ]
+}

--- a/master_lb.tf
+++ b/master_lb.tf
@@ -4,10 +4,11 @@ resource "aws_elb" "master" {
   security_groups = ["${module.master.sg}"]
 
   listener {
-    instance_port     = 8443
-    instance_protocol = "tcp"
-    lb_port           = 8443
-    lb_protocol       = "tcp"
+    instance_port      = 8443
+    instance_protocol  = "https"
+    lb_port            = 8443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${aws_acm_certificate.public_cert.arn}"
   }
 
   health_check {

--- a/provisioner_user_data.tpl
+++ b/provisioner_user_data.tpl
@@ -34,7 +34,7 @@ write_files:
       #      vpc_destination_variable = Name
       #      hotname_variable = Name
       #      pattern_include = openshift*
-      instance_filters = tag:Name=openshift*
+      instance_filters = tag:Environment=${environment}
 
       route53 = False
       all_instances = False
@@ -221,4 +221,6 @@ runcmd:
   - ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && rm -f /root/.ssh/id_rsa.pub
   - aws ssm get-parameters --names "${environment}.provisioner_id_rsa" --with-decryption --region ${region} --output json|jq -r '.|{Parameters}[][]|.Value'>/root/.ssh/id_rsa
   - aws ssm send-command --document-name ${ssm} --targets Key=tag:Name,Values=provisioner --region ${region}
+  - echo Make sure we have Ansible 2.4.3
+  - rpm -Uvh https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.4.3.0-1.el7.ans.noarch.rpm
   - /bin/provisioner.sh


### PR DESCRIPTION
This is a small change that introduce ACM certificate to be used on the public ELBs

Also, we install the correct version of Ansible, since the latest code doesn't support Ansible 2.4.2 anylonger